### PR TITLE
Fixed info API bug.

### DIFF
--- a/app/code/community/ShipStream/Sync/Model/Api.php
+++ b/app/code/community/ShipStream/Sync/Model/Api.php
@@ -18,8 +18,8 @@ class ShipStream_Sync_Model_Api extends Mage_Api_Model_Resource_Abstract
         $result = [];
         $result['magento_edition'] = Mage::getEdition();
         $result['magento_version'] = Mage::getVersion();
-        $result['openmage_version'] = function_exists('Mage::getOpenMageVersion') ? Mage::getOpenMageVersion() : '';
-        $result['shipstream_sync_version'] = Mage::getConfig()->getModuleConfig('ShipStream_Sync')->version;
+        $result['openmage_version'] = method_exists('Mage','getOpenMageVersion') ? Mage::getOpenMageVersion() : '';
+        $result['shipstream_sync_version'] = (string) Mage::getConfig()->getModuleConfig('ShipStream_Sync')->version;
         return $result;
     }
 


### PR DESCRIPTION
Before fix:

```bash
kiatng@win10:~/shipstream/middleware$ bin/mwrun ShipStream_Magento1 --diagnostics
Creating middleware_cli_run ... done

Diagnostic information for ShipStream_Magento1 reported at 2021-06-04T13:11:05+00:00
---------------------------------------------------------------------------------
Connection is configured.
Internal error!! This should not happen, all exceptions must be parents of Plugin_Exception.
Error: Object of class stdClass could not be converted to string in /var/www/html/.modman/plugin-openmage/app/code/community/ShipStream/Magento1/Plugin.php:37
Stack trace:
#0 /var/www/html/.modman/plugin-openmage/app/code/community/ShipStream/Magento1/Plugin.php(37): sprintf('ShipStream Sync...', Object(stdClass))
#1 /var/www/html/app/bootstrap.php(87): ShipStream_Magento1_Plugin->connectionDiagnostics()
#2 /var/www/html/run.php(57): Middleware->diagnostics()
#3 {main}
---------------------------------------------------------------------------------
```

Try again after first fix:
```
kiatng@win10:~/shipstream/middleware$ bin/mwrun ShipStream_Magento1 --diagnostics
Creating middleware_cli_run ... done

Diagnostic information for ShipStream_Magento1 reported at 2021-06-04T13:19:00+00:00
---------------------------------------------------------------------------------
Connection is configured.
Magento Edition: Community
Magento Version: 1.9.4.5
OpenMage Version: 
ShipStream Sync Version: 1.0
---------------------------------------------------------------------------------
```

After 2nd fix:

```bash
kiatng@win10:~/shipstream/middleware$ bin/mwrun ShipStream_Magento1 --diagnostics
Creating middleware_cli_run ... done

Diagnostic information for ShipStream_Magento1 reported at 2021-06-04T13:26:20+00:00
---------------------------------------------------------------------------------
Connection is configured.
Magento Edition: Community
Magento Version: 1.9.4.5
OpenMage Version: 20.0.10
ShipStream Sync Version: 1.0
---------------------------------------------------------------------------------
```